### PR TITLE
[SALL-03] feature: 토큰 재발급 api 구현, 시크릿키 .env 분리, 만료시간 .yml 분리

### DIFF
--- a/.example.env
+++ b/.example.env
@@ -5,3 +5,4 @@ DB_USERNAME=db_username
 DB_PASSWORD=db_password
 SPRING_PROFILES_ACTIVE=dev
 JPA_HIBERNATE_DDL_AUTO=update
+JWT_SECRET=your-256-bit-secret-key-example

--- a/src/main/java/me/sallim/api/auth/controller/AuthController.java
+++ b/src/main/java/me/sallim/api/auth/controller/AuthController.java
@@ -1,6 +1,7 @@
 package me.sallim.api.auth.controller;
 
 import io.swagger.v3.oas.annotations.Operation;
+import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
 import me.sallim.api.auth.service.AuthService;
 import me.sallim.api.domain.member.model.Member;
@@ -63,7 +64,8 @@ public class AuthController {
     """
     )
     @PostMapping("/reissue")
-    public ResponseEntity<?> reissue(@RequestHeader(value = "Authorization", required = false) String refreshTokenHeader) {
+    public ResponseEntity<?> reissue(HttpServletRequest request) {
+        String refreshTokenHeader = request.getHeader("Authorization");
         TokenResponseDTO token = authService.reissue(refreshTokenHeader);
         return ResponseEntity.ok(ApiResponse.success(token));
     }

--- a/src/main/java/me/sallim/api/auth/controller/AuthController.java
+++ b/src/main/java/me/sallim/api/auth/controller/AuthController.java
@@ -9,10 +9,7 @@ import me.sallim.api.global.response.ApiResponse;
 import me.sallim.api.global.security.dto.LoginRequestDTO;
 import me.sallim.api.global.security.dto.TokenResponseDTO;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequestMapping("/auth")
@@ -48,5 +45,26 @@ public class AuthController {
     public ResponseEntity<?> logout(@LoginMember Member member) {
         authService.logout(member.getId());
         return ResponseEntity.ok(ApiResponse.success("로그아웃 성공"));
+    }
+
+    @Operation(
+            summary = "Access/Refresh 토큰 재발급 API",
+            description = """
+    저장된 Refresh Token을 통해 Access Token을 재발급합니다.
+    efresh Token을 헤더에 설정한 후 요청.
+
+    ### 응답 예시:
+    ```json
+    {
+      "access-token": "new-access-token-abc",
+      "refresh-token": "new-refresh-token-xyz"
+    }
+    ```
+    """
+    )
+    @PostMapping("/reissue")
+    public ResponseEntity<?> reissue(@RequestHeader(value = "Authorization", required = false) String refreshTokenHeader) {
+        TokenResponseDTO token = authService.reissue(refreshTokenHeader);
+        return ResponseEntity.ok(ApiResponse.success(token));
     }
 }

--- a/src/main/java/me/sallim/api/global/security/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/me/sallim/api/global/security/jwt/JwtAuthenticationFilter.java
@@ -30,7 +30,7 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
             FilterChain filterChain)
             throws ServletException, IOException {
 
-        String token = resolveToken(request);
+        String token = jwtTokenProvider.resolveToken(request.getHeader("Authorization"));
 
         if (token != null && jwtTokenProvider.validateToken(token)) {
             String username = jwtTokenProvider.getSubject(token);
@@ -47,10 +47,5 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
         }
 
         filterChain.doFilter(request, response);
-    }
-
-    private String resolveToken(HttpServletRequest request) {
-        String bearer = request.getHeader("Authorization");
-        return (bearer != null && bearer.startsWith("Bearer ")) ? bearer.substring(7) : null;
     }
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -23,3 +23,7 @@ spring:
         hbm2ddl:
           auto: ${JPA_HIBERNATE_DDL_AUTO:none}
         default_batch_fetch_size: 1000
+  jwt:
+    secret: ${JWT_SECRET}
+    access-token-validity-in-seconds: 2592000
+    refresh-token-validity-in-seconds: 2592000


### PR DESCRIPTION
## #️⃣ 요약 설명
<!-- 구현한 기능에 대한 간단한 설명 해주세요 -->
<!-- ex) 회원 정보 조회 API 구현 -->

1. 토큰 재발급 api 구현 (access token, refresh 토큰 모두 함께 재발급)
2. 시크릿키를 .env에 분리
3. 토큰 만료시간을 .yml에 분리

하였습니다.

## 📝 작업 내용

> 코드의 흐름이나 중요한 부분을 작성해주세요.
> 
```java
// 핵심 코드를 붙여넣기 해주세요
```
코드에 대한 간단한 설명 부탁드립니다.

## 동작 확인

> 기능을 실행했을 때 정상 동작하는지 여부를 확인하고 사진을 올려주세요
> 
> ex) 테스트 코드 작성후 성공 사진 
> ex) swagger 사진


## 💬 리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?


시크릿키를 .yml에 아래와 같이 추가해주세요
JWT_SECRET= ~~~

