### PR TITLE
refac: 댓글 조회시 nickname 추가, 판매글 상세조회시 nickname null 해결

### DIFF
--- a/src/main/java/me/sallim/api/domain/product/repository/ProductRepository.java
+++ b/src/main/java/me/sallim/api/domain/product/repository/ProductRepository.java
@@ -3,11 +3,16 @@ package me.sallim.api.domain.product.repository;
 import me.sallim.api.domain.member.model.Member;
 import me.sallim.api.domain.product.model.Product;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.List;
+import java.util.Optional;
 
 public interface ProductRepository extends JpaRepository<Product, Long> {
 
     void delete(Product product);
     List<Product> findByMember(Member member);
+    @Query("SELECT p FROM Product p JOIN FETCH p.member WHERE p.id = :id")
+    Optional<Product> findByIdWithMember(@Param("id") Long id);
 }

--- a/src/main/java/me/sallim/api/domain/product_comment/dto/response/ProductCommentResponse.java
+++ b/src/main/java/me/sallim/api/domain/product_comment/dto/response/ProductCommentResponse.java
@@ -7,12 +7,14 @@ import me.sallim.api.domain.product_comment.model.ProductComment;
 public record ProductCommentResponse(
         Long commentId,
         Long memberId,
+        String nickname,
         String content
 ) {
     public static ProductCommentResponse from(ProductComment comment) {
         return new ProductCommentResponse(
                 comment.getId(),
-                comment.getMemberId(),
+                comment.getMember().getId(),
+                comment.getMember().getNickname(),
                 comment.getContent()
         );
     }

--- a/src/main/java/me/sallim/api/domain/product_comment/model/ProductComment.java
+++ b/src/main/java/me/sallim/api/domain/product_comment/model/ProductComment.java
@@ -2,6 +2,7 @@ package me.sallim.api.domain.product_comment.model;
 
 import jakarta.persistence.*;
 import lombok.*;
+import me.sallim.api.domain.member.model.Member;
 import me.sallim.api.domain.product.model.Product;
 import me.sallim.api.global.entity.BaseEntity;
 
@@ -22,8 +23,9 @@ public class ProductComment extends BaseEntity {
     @JoinColumn(name = "product_id", nullable = false)
     private Product product;
 
-    @Column(nullable = false)
-    private Long memberId;
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "member_id", nullable = false)
+    private Member member;
 
     @Column(length = 2048)
     private String content;

--- a/src/main/java/me/sallim/api/domain/product_comment/service/ProductCommentService.java
+++ b/src/main/java/me/sallim/api/domain/product_comment/service/ProductCommentService.java
@@ -28,7 +28,7 @@ public class ProductCommentService {
 
         ProductComment comment = ProductComment.builder()
                 .product(product)
-                .memberId(loginMember.getId())
+                .member(loginMember)
                 .content(request.content())
                 .build();
 
@@ -48,7 +48,7 @@ public class ProductCommentService {
         ProductComment comment = productCommentRepository.findById(commentId)
                 .orElseThrow(() -> new IllegalArgumentException("댓글을 찾을 수 없습니다."));
 
-        if (!comment.getMemberId().equals(loginMember.getId())) {
+        if (!comment.getMember().getId().equals(loginMember.getId())) {
             throw new IllegalArgumentException("본인이 작성한 댓글만 삭제할 수 있습니다.");
         }
 

--- a/src/main/java/me/sallim/api/domain/product_selling/dto/response/ProductSellingDetailResponse.java
+++ b/src/main/java/me/sallim/api/domain/product_selling/dto/response/ProductSellingDetailResponse.java
@@ -21,7 +21,8 @@ public record ProductSellingDetailResponse(
         int price,
         int userPrice,
         List<ProductSellingAnswerResponse> answers,
-        boolean isAuthor
+        boolean isAuthor,
+        String nickname
 ) {
     public static ProductSellingDetailResponse from(ProductSelling selling, Product product, List<ProductSellingAnswer> answers) {
         return ProductSellingDetailResponse.builder()
@@ -36,6 +37,7 @@ public record ProductSellingDetailResponse(
                 .userPrice(selling.getUserPrice())
                 .answers(answers.stream().map(ProductSellingAnswerResponse::from).toList())
                 .isAuthor(false) // Default value, will be updated in service if needed
+                .nickname(product.getMember().getNickname())
                 .build();
     }
 }

--- a/src/main/java/me/sallim/api/domain/product_selling/service/ProductSellingService.java
+++ b/src/main/java/me/sallim/api/domain/product_selling/service/ProductSellingService.java
@@ -80,7 +80,7 @@ public class ProductSellingService {
 
     @Transactional(readOnly = true)
     public ProductSellingDetailResponse getProductSellingDetail(Long productId, Member currentMember) {
-        Product product = productRepository.findById(productId)
+        Product product = productRepository.findByIdWithMember(productId)
                 .orElseThrow(() -> new IllegalArgumentException("해당 제품이 존재하지 않습니다."));
 
         ProductSelling selling = productSellingRepository.findByProduct(product)
@@ -105,12 +105,13 @@ public class ProductSellingService {
                 .userPrice(selling.getUserPrice())
                 .answers(answers.stream().map(ProductSellingAnswerResponse::from).toList())
                 .isAuthor(isAuthor)
+                .nickname(product.getMember().getNickname())
                 .build();
     }
 
     @Transactional
     public ProductSellingDetailResponse updateSellingProduct(Member loginMember, Long productId, UpdateProductSellingRequest request) {
-        Product product = productRepository.findById(productId)
+        Product product = productRepository.findByIdWithMember(productId)
                 .orElseThrow(() -> new IllegalArgumentException("해당 제품이 존재하지 않습니다."));
 
         if (!product.getMember().getId().equals(loginMember.getId())) {
@@ -190,7 +191,7 @@ public class ProductSellingService {
 
     @Transactional
     public void deleteSellingProduct(Member loginMember, Long productId) {
-        Product product = productRepository.findById(productId)
+        Product product = productRepository.findByIdWithMember(productId)
                 .orElseThrow(() -> new IllegalArgumentException("해당 제품이 존재하지 않습니다."));
 
         if (!product.getMember().getId().equals(loginMember.getId())) {


### PR DESCRIPTION
## #️⃣ 요약 설명
<!-- 구현한 기능에 대한 간단한 설명 해주세요 -->
<!-- ex) 회원 정보 조회 API 구현 -->

1. 댓글 조회시 작성자 nickname이 함께 조회되도록 하였습니다.
2. 판매글 단건 상세 조회시 nickname이 null로 표시되는 문제를 해결하였습니다.

## 📝 작업 내용

> 코드의 흐름이나 중요한 부분을 작성해주세요.
> 
```java
// 핵심 코드를 붙여넣기 해주세요
```
코드에 대한 간단한 설명 부탁드립니다.

## 동작 확인

> 기능을 실행했을 때 정상 동작하는지 여부를 확인하고 사진을 올려주세요
> 
> ex) 테스트 코드 작성후 성공 사진 
> ex) swagger 사진

## 💬 리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
